### PR TITLE
Added drain hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - "9"
   - "8"
   - "6"
   - "4"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ async function nestedJob (child) {
   // perform some work
 })
 ```
+
+If you need to know when a queue has finished all its jobs, you can use the `drain` api.  
+*Note that in the top queue the drain hook can be called multiple times.*
+```js
+const q = require('workq')()
+
+q.drain(done => {
+  // the current queue has finished its jobs
+  // async await is supported as well
+  done()
+})
+
+q.add(job)
+
+function job (child, done) {
+  // perform some work
+  // you can add nested jobs!
+  child.add(nestedJob)
+  done()
+})
+
+function nestedJob (child, done) {
+  // perform some work
+  done()
+})
+```
 ## Acknowledgements
 
 This project is kindly sponsored by [LetzDoIt](http://www.letzdoitapp.com/).

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -65,6 +65,43 @@ function asyncAwait (Queue, test) {
       t.is(order.shift(), 7)
     })
   })
+
+  test('Drain hook', t => {
+    t.plan(7)
+
+    const q = Queue()
+    const order = [1, 2, 3, 4, 5]
+
+    q.drain(async () => {
+      await sleep(100)
+      t.ok('called')
+    })
+
+    q.add(async q => {
+      t.is(order.shift(), 1)
+    })
+
+    q.add(async q => {
+      t.is(order.shift(), 2)
+
+      q.add(async q => {
+        t.is(order.shift(), 3)
+      })
+
+      q.drain(async () => {
+        await sleep(100)
+        t.ok('called')
+      })
+    })
+
+    q.add(async q => {
+      t.is(order.shift(), 4)
+    })
+
+    q.add(async q => {
+      t.is(order.shift(), 5)
+    })
+  })
 }
 
 module.exports = asyncAwait


### PR DESCRIPTION
As titled, see https://github.com/delvedor/workq/issues/2.

Inside a drain you cannot add new jobs to the current queue.
If you use it in the top level queue, it will be called multiple times.

cc @StarpTech