### PR TITLE
inherit properties from prototype, add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # vim swap files
 *.swp
+
+#lock
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,5 @@ typings/
 # vim swap files
 *.swp
 
-#lock
+# NPM lock file
 package-lock.json

--- a/example.js
+++ b/example.js
@@ -3,6 +3,11 @@
 const Queue = require('./index')
 const q = Queue()
 
+q.drain((done) => {
+  console.log('Drain')
+  done()
+})
+
 q.add((q, done) => {
   console.log(1)
   done()

--- a/index.js
+++ b/index.js
@@ -79,7 +79,12 @@ function runner () {
     return
   }
 
-  const child = new Queue()
+  // inherit properties from prototype
+  const child = Object.create(this)
+  child.q = []
+  child.running = false
+  child._exhausted = false
+  child._id = id++
   child._parent = this
   child._pause = true
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ function Queue (opts) {
   this.running = false
   // private api
   this._exhausted = false
+  this._shareDrainHandler = opts.shareDrainHandler
   this._parent = null
   this._pause = false
   this._id = id++
@@ -87,6 +88,10 @@ function runner () {
   child._id = id++
   child._parent = this
   child._pause = true
+
+  if (!child._shareDrainHandler) {
+    child._drain = drain.bind(child)
+  }
 
   const asyncOp = job(child, done.bind(this))
   if (asyncOp && typeof asyncOp.then === 'function') {

--- a/index.js
+++ b/index.js
@@ -80,19 +80,7 @@ function runner () {
     return
   }
 
-  // inherit properties from prototype
-  const child = Object.create(this)
-  child.q = []
-  child.running = false
-  child._exhausted = false
-  child._id = id++
-  child._parent = this
-  child._pause = true
-
-  if (!child._shareDrainHandler) {
-    child._drain = drain.bind(child)
-  }
-
+  const child = createChild(this)
   const asyncOp = job(child, done.bind(this))
   if (asyncOp && typeof asyncOp.then === 'function') {
     this._pause = true
@@ -123,6 +111,22 @@ function runner () {
       }
     }
   }
+}
+
+function createChild (parentQ) {
+  // inherit properties from prototype
+  const child = Object.create(parentQ)
+  child.q = []
+  child.running = false
+  child._exhausted = false
+  child._id = id++
+  child._parent = parentQ
+  child._pause = true
+
+  if (!child._shareDrainHandler) {
+    child._drain = drain.bind(child)
+  }
+  return child
 }
 
 function parent () {

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -102,6 +102,38 @@ function asyncAwait (Queue, test) {
       t.is(order.shift(), 5)
     })
   })
+
+  test('Use drain handler from parent queue', t => {
+    t.plan(7)
+
+    const q = Queue()
+    const order = [1, 2, 3, 4, 5]
+
+    q.drain(async () => {
+      await sleep(100)
+      t.ok('called') // Is called twice
+    })
+
+    q.add(async q => {
+      t.is(order.shift(), 1)
+    })
+
+    q.add(async q => {
+      t.is(order.shift(), 2)
+
+      q.add(async q => {
+        t.is(order.shift(), 3)
+      })
+    })
+
+    q.add(async q => {
+      t.is(order.shift(), 4)
+    })
+
+    q.add(async q => {
+      t.is(order.shift(), 5)
+    })
+  })
 }
 
 module.exports = asyncAwait

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -106,7 +106,7 @@ function asyncAwait (Queue, test) {
   test('Use drain handler from parent queue', t => {
     t.plan(7)
 
-    const q = Queue()
+    const q = Queue({ shareDrainHandler: true })
     const order = [1, 2, 3, 4, 5]
 
     q.drain(async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -698,7 +698,7 @@ test('Drain hook', t => {
 test('Use drain handler from parent queue', t => {
   t.plan(7)
 
-  const q = Queue()
+  const q = Queue({ shareDrainHandler: true })
   const order = [1, 2, 3, 4, 5]
 
   q.drain(done => {

--- a/test/test.js
+++ b/test/test.js
@@ -695,6 +695,44 @@ test('Drain hook', t => {
   })
 })
 
+test('Use drain handler from parent queue', t => {
+  t.plan(7)
+
+  const q = Queue()
+  const order = [1, 2, 3, 4, 5]
+
+  q.drain(done => {
+    t.ok('called') // Is called twice
+    done()
+  })
+
+  q.add((q, done) => {
+    t.is(order.shift(), 1)
+    done()
+  })
+
+  q.add((q, done) => {
+    t.is(order.shift(), 2)
+
+    q.add((q, done) => {
+      t.is(order.shift(), 3)
+      done()
+    })
+
+    done()
+  })
+
+  q.add((q, done) => {
+    t.is(order.shift(), 4)
+    done()
+  })
+
+  q.add((q, done) => {
+    t.is(order.shift(), 5)
+    done()
+  })
+})
+
 test('Drain should be a function', t => {
   t.plan(1)
 


### PR DESCRIPTION
I need this feature because I don't want to define a `onDrain` handler on any new queue. This PR can simplify it to listen to "end" events with a single handler.